### PR TITLE
docs: deprecation notice — migrate to ovos-stt-plugin-wav2vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
+> **This repository is archived. No further updates will be made.**
+> This plugin has been superseded by [ovos-stt-plugin-wav2vec](https://github.com/OpenVoiceOS/ovos-stt-plugin-wav2vec2). See the migration guide below.
+
 # OVOS MMS STT
 
-OVOS plugin for [The Massively Multilingual Speech (MMS) project](https://huggingface.co/docs/transformers/main/en/model_doc/mms)
+OVOS plugin for [The Massively Multilingual Speech (MMS) project](https://huggingface.co/docs/transformers/main/en/model_doc/mms).
 
 ## Description
 
 > Expanding the language coverage of speech technology has the potential to improve access to information for many more people. However, current speech technology is restricted to about one hundred languages which is a small fraction of the over 7,000 languages spoken around the world. The Massively Multilingual Speech (MMS) project increases the number of supported languages by 10-40x, depending on the task. The main ingredients are a new dataset based on readings of publicly available religious texts and effectively leveraging self-supervised learning. We built pre-trained wav2vec 2.0 models covering 1,406 languages, a single multilingual automatic speech recognition model for 1,107 languages, speech synthesis models for the same number of languages, as well as a language identification model for 4,017 languages. Experiments show that our multilingual speech recognition model more than halves the word error rate of Whisper on 54 languages of the FLEURS benchmark while being trained on a small fraction of the labeled data.
 
-The equivalent TTS models can be used via [ovos-tts-plugin-coqui](https://github.com/OpenVoiceOS/ovos-tts-plugin-coqui) fairseq models
+## Migration Guide
 
-## Install
+Install the parent plugin:
 
-`pip install ovos-stt-plugin-mms`
+```bash
+pip install ovos-stt-plugin-wav2vec
+```
 
-## Configuration
+Update your `mycroft.conf`:
 
 ```json
 "stt": {
-    "module": "ovos-stt-plugin-mms",
-    "ovos-stt-plugin-mms": {
-      "model": "facebook/mms-1b-all"
+    "module": "ovos-stt-plugin-wav2vec",
+    "ovos-stt-plugin-wav2vec": {
+        "model": "facebook/mms-1b-all"
     }
 }
 ```
 
-valid models: `facebook/mms-1b-all`, `facebook/mms-1b-l1107`, `facebook/mms-1b-fl102`
+Available MMS models:
 
+| Model | Languages |
+|-------|-----------|
+| `facebook/mms-1b-all` | 1,107 languages |
+| `facebook/mms-1b-l1107` | 1,107 languages (alternative checkpoint) |
+| `facebook/mms-1b-fl102` | 102 languages |
 
 ## Credits
 


### PR DESCRIPTION
> **This repository is archived. No further updates will be made.**

Add deprecation notice and migration guide pointing to the parent plugin.